### PR TITLE
point people to twigjs/twigjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+This project is no longer maintained. Please see the active js port of Twig at https://github.com/twigjs/twig.js/
+
+-----
+
 # TwigJS
 
 A port of PHP template engine (www.twig-project.org) to Javascript


### PR DESCRIPTION
Due to a known bug in GitHub's search function, searching for "twigjs" doesn't turn up https://github.com/twigjs/twig.js/, the actively maintained JS Twig port. This repo is the top in the results list. This PR adds a note to the top of the page pointing people to the active project.

It would also be nice to update the short description, which it isn't possible to make PRs for. Something like

<kbd><img width="857" alt="screen shot 2017-03-04 at 16 39 35" src="https://cloud.githubusercontent.com/assets/3282350/23582492/54792fb6-00f9-11e7-92b8-4427a211dbd2.png"></kbd>